### PR TITLE
Massive data structure overhaul

### DIFF
--- a/packages/client/lib/components/Board.tsx
+++ b/packages/client/lib/components/Board.tsx
@@ -1,7 +1,6 @@
 import React, { useEffect } from "react";
 import { playerData } from "../interfaces/types";
-import { shipLengths } from "../constants";
-import placeShip from "../functions/placeShip";
+import Cell from "./Cell";
 
 export interface Board {
   playerData: playerData;
@@ -25,38 +24,42 @@ const Board = (props: Board) => {
   }, []);
 
   return (
-    <>
-      {props.playerData.board.map((column, i) => (
-        <div key={i} id={`column-${i}`}>
-          {column.map((value, j) => (
-            <div
-              key={j}
-              id={`row-${j}`}
-              onMouseUp={() => {
-                if (!props.isShipSelected || !props.setIsShipSelected) return;
-                placeShip(
-                  props.playerData.board,
-                  props.selectedShipIndex,
-                  i,
-                  j,
-                  props.orientation,
-                  props.setPlayerData
+    <div className="grid-value battleship-grid">
+      {Array(10)
+        .fill(0)
+        .map((val, i) => (
+          <div key={i} id={`column-${i}`}>
+            {Array(10)
+              .fill(0)
+              .map((val, j) => {
+                const test = props.playerData.shipInfo.find(
+                  (ship) =>
+                    ship.placed &&
+                    ship.partArray.find(
+                      (part) => part.location[0] === i && part.location[1] === j
+                    )
                 );
-                props.setIsShipSelected(false);
-              }}
-              onMouseDown={() => {
-                // This is to prevent type error of null provoke
-                if (!props.setUserFireLocation || !props.setUserTurn) return;
-                //send clicked coord to a function that checks
-                props.setUserFireLocation([i, j]);
-              }}
-            >
-              {value}
-            </div>
-          ))}
-        </div>
-      ))}
-    </>
+
+                return (
+                  <Cell
+                    key={j}
+                    playerData={props.playerData}
+                    setPlayerData={props.setPlayerData}
+                    selectedShipIndex={props.selectedShipIndex}
+                    setIsShipSelected={props.setIsShipSelected}
+                    isShipSelected={props.isShipSelected}
+                    orientation={props.orientation}
+                    setUserTurn={props.setUserTurn}
+                    setUserFireLocation={props.setUserFireLocation}
+                    coords={[i, j]}
+                  >
+                    {test ? test.partArray.length : 0}
+                  </Cell>
+                );
+              })}
+          </div>
+        ))}
+    </div>
   );
 };
 

--- a/packages/client/lib/components/Cell.tsx
+++ b/packages/client/lib/components/Cell.tsx
@@ -1,0 +1,48 @@
+import React from "react";
+import placeShip from "../functions/placeShip";
+import { playerData } from "../interfaces/types";
+
+interface Props extends React.HTMLAttributes<HTMLDivElement> {
+  playerData: playerData;
+  setPlayerData: React.Dispatch<React.SetStateAction<playerData>>;
+  selectedShipIndex: number | -1; // I want to make this optional too
+  setIsShipSelected?: React.Dispatch<React.SetStateAction<boolean>>;
+  isShipSelected?: boolean;
+  orientation?: "horizontal" | "vertical";
+  setUserTurn?: React.Dispatch<React.SetStateAction<boolean>>;
+  setUserFireLocation?: React.Dispatch<React.SetStateAction<number[]>>;
+  coords: number[];
+}
+
+const Cell = (props: Props) => {
+  return (
+    <div
+      id={`row-${props.coords[1]}`}
+      onMouseUp={() => {
+        if (
+          !props.isShipSelected ||
+          !props.setIsShipSelected ||
+          !props.orientation
+        )
+          return;
+        placeShip(
+          props.selectedShipIndex,
+          props.coords,
+          props.orientation,
+          props.playerData.shipInfo
+        );
+        props.setIsShipSelected(false);
+      }}
+      onMouseDown={() => {
+        // This is to prevent type error of null provoke
+        if (!props.setUserFireLocation || !props.setUserTurn) return;
+        //send clicked coord to a function that checks
+        props.setUserFireLocation(props.coords);
+      }}
+    >
+      {props.children}
+    </div>
+  );
+};
+
+export default Cell;

--- a/packages/client/lib/constants/index.tsx
+++ b/packages/client/lib/constants/index.tsx
@@ -4,27 +4,27 @@ export const initialData = [
   {
     shipType: "destroyer",
     placed: false,
-    placedLocation: [],
+    partArray: [],
   },
   {
     shipType: "submarine",
     placed: false,
-    placedLocation: [],
+    partArray: [],
   },
   {
     shipType: "cruiser",
     placed: false,
-    placedLocation: [],
+    partArray: [],
   },
   {
     shipType: "battleship",
     placed: false,
-    placedLocation: [],
+    partArray: [],
   },
   {
     shipType: "carrier",
     placed: false,
-    placedLocation: [],
+    partArray: [],
   },
 ];
 

--- a/packages/client/lib/functions/generateRandomPlacements.ts
+++ b/packages/client/lib/functions/generateRandomPlacements.ts
@@ -1,5 +1,5 @@
 import { initialData, shipLengths } from "../constants";
-import { playerData, ShipInfo, shipLength } from "../interfaces/types";
+import { playerData, ShipInfo } from "../interfaces/types";
 import placeShip from "./placeShip";
 
 /**Places ships from randomly generated coordinates that is not outside the grid or already occupied on any provided 10*10 grid*/

--- a/packages/client/lib/functions/generateRandomPlacements.ts
+++ b/packages/client/lib/functions/generateRandomPlacements.ts
@@ -1,15 +1,18 @@
-import { initialData } from "../constants";
-import { playerData } from "../interfaces/types";
+import { initialData, shipLengths } from "../constants";
+import { playerData, ShipInfo, shipLength } from "../interfaces/types";
 import placeShip from "./placeShip";
 
 /**Places ships from randomly generated coordinates that is not outside the grid or already occupied on any provided 10*10 grid*/
 const generateRandomPlacements = (
-  board: number[][],
-  setPlayerData: React.Dispatch<React.SetStateAction<playerData>>
-): number[][] => {
+  setPlayerData: React.Dispatch<React.SetStateAction<playerData>>,
+  playerData: playerData
+) => {
+  let shipInfo: ShipInfo[] = JSON.parse(JSON.stringify(playerData.shipInfo));
+  let finalShipInfo: ShipInfo[];
+
   for (let shipIndex = 0; shipIndex < initialData.length; shipIndex++) {
     const width = 10;
-    let placed = false;
+    let placed: ShipInfo[] | undefined = undefined;
     while (!placed) {
       const orientation =
         Math.round(Math.random()) >= 0.5 ? "horizontal" : "vertical";
@@ -17,18 +20,23 @@ const generateRandomPlacements = (
       const x = Math.floor(Math.random() * width);
       const y = Math.floor(Math.random() * width);
 
-      console.log(shipIndex);
+      console.log(
+        "Placing ship of length",
+        shipLengths[shipIndex],
+        orientation
+      );
       console.log("[" + x, y + "]");
 
-      if (
-        placeShip(board, shipIndex, x, y, orientation, setPlayerData) === false
-      ) {
-        placed = false;
-      } else placed = true;
+      placed = placeShip(shipIndex, [x, y], orientation, shipInfo);
+    }
+    if (placed) {
+      finalShipInfo = placed;
+    } else {
+      throw new Error("No ship placed");
     }
   }
 
-  return board;
+  setPlayerData((prev) => ({ ...prev, shipInfo: finalShipInfo }));
 };
 
 export default generateRandomPlacements;

--- a/packages/client/lib/functions/placeShip.ts
+++ b/packages/client/lib/functions/placeShip.ts
@@ -1,5 +1,4 @@
-import React from "react";
-import { playerData, ShipInfo, ShipPart } from "../interfaces/types";
+import { playerData, ShipPart } from "../interfaces/types";
 import { shipLengths } from "../constants";
 import { shipsInCoord } from "./shipsInCoord";
 

--- a/packages/client/lib/functions/placeShip.tsx
+++ b/packages/client/lib/functions/placeShip.tsx
@@ -1,24 +1,26 @@
 import React from "react";
-import { playerData } from "../interfaces/types";
+import { playerData, ShipInfo, ShipPart } from "../interfaces/types";
 import { shipLengths } from "../constants";
+import { shipsInCoord } from "./shipsInCoord";
 
 /**Places down ship on drag ending point respective to the cursor position
  *
- * @param index is the index of selected Ship
+ * @param selectedShipIndex is the index of selected Ship
  * Working with index here because there are 2 diff ships with same length of 3
  * @returns updated board: number[][] after placement
  */
 const placeShip = (
-  board: number[][],
-  index: number | -1,
-  x: number,
-  y: number,
-  orientation: "horizontal" | "vertical" | undefined,
-  setPlayerData: React.Dispatch<React.SetStateAction<playerData>>
+  selectedShipIndex: number | -1,
+  cellCoords: number[],
+  orientation: "horizontal" | "vertical",
+  shipInfo: playerData["shipInfo"]
 ) => {
-  //   if (x === -1 || y === -1) return -1;
-  const xrange = x + shipLengths[index];
-  const yrange = y + shipLengths[index];
+  // Create a deep copy of shipInfo to avoid mutating state
+
+  const shipLength = shipLengths[selectedShipIndex];
+  const [x, y] = cellCoords;
+  const xrange = x + shipLength;
+  const yrange = y + shipLength;
 
   const goesOutsideGrid = () => {
     if (orientation === "horizontal" && xrange > 10) {
@@ -29,67 +31,53 @@ const placeShip = (
       console.log("goesOutsideGrid");
       return true;
     }
-    return false;
+    return undefined;
   };
 
   /** True if neighbouring x or y + ... ship length coordinates is not occupied + !isOutsideGrid */
   const isLocationPlaceable = (x: number, y: number) => {
-    if (goesOutsideGrid()) return false;
-
     if (orientation === "horizontal") {
       for (let i = x; i < xrange; i++) {
-        if (board[i][y] !== 0) {
-          return false;
+        console.log("Checking for ship at " + i + ", " + y);
+        const foundShips = shipsInCoord(shipInfo, [i, y]);
+        if (foundShips) {
+          console.log("shipsFound", foundShips);
+          return undefined;
         }
       }
-    }
-    if (orientation === "vertical") {
+    } else {
       for (let j = y; j < yrange; j++) {
-        if (board[x][j] !== 0) {
-          return false;
+        const foundShips = shipsInCoord(shipInfo, [x, j]);
+        if (foundShips) {
+          console.log("shipsFound", foundShips);
+
+          return undefined;
         }
       }
     }
+
     return true;
   };
 
-  /** Updates both the placedLocation and the board */
-  const updateShipPlacement = (x: number, y: number) => {
-    setPlayerData((prev) => {
-      const updatedBoard = prev.board.map((row, i) => {
-        if (i === x) {
-          return row.map((cell, j) => (j === y ? shipLengths[index] : cell));
-        }
-        return row;
-      });
-      const updatedShipInfo = prev.shipInfo.map((ship, i) =>
-        i === index
-          ? {
-              ...ship,
-              placed: true,
-              placedLocation: [...ship.placedLocation, [x, y]],
-            }
-          : ship
-      );
-      return { ...prev, board: updatedBoard, shipInfo: updatedShipInfo };
-    });
-  };
-
-  if (orientation === "horizontal" && isLocationPlaceable(x, y)) {
-    if (xrange > 10) return -1;
-    for (x; x < xrange; x++) {
-      updateShipPlacement(x, y);
-    }
-  } else if (orientation === "vertical" && isLocationPlaceable(x, y)) {
-    if (yrange > 10) return -1;
-    for (y; y < yrange; y++) {
-      updateShipPlacement(x, y);
-    }
+  if (goesOutsideGrid() || !isLocationPlaceable(x, y)) {
+    console.log("PLACABLE: " + false);
+    return undefined;
   }
 
-  console.log("PLACABLE: " + isLocationPlaceable(x, y));
+  const partArray: ShipPart[] = Array(shipLength);
 
-  return isLocationPlaceable(x, y) ? board : false;
+  for (let i = 0; i < shipLength; i++) {
+    partArray[i] = {
+      location: orientation === "horizontal" ? [x + i, y] : [x, y + i],
+      hit: false,
+    };
+  }
+
+  shipInfo[selectedShipIndex].partArray = partArray;
+  shipInfo[selectedShipIndex].placed = true;
+
+  console.log("PLACABLE: " + true);
+  return shipInfo;
 };
 
 export default placeShip;

--- a/packages/client/lib/functions/shipsInCoord.ts
+++ b/packages/client/lib/functions/shipsInCoord.ts
@@ -1,0 +1,21 @@
+import { shipLengths } from "../constants";
+import { ShipInfo } from "../interfaces/types";
+
+export const shipsInCoord = (shipInfo: ShipInfo[], coords: number[]) => {
+  const [x, y] = coords;
+
+  return shipInfo.find((ship, index) => {
+    console.log(
+      `Comparing with ship of length ${shipLengths[index]}, ${
+        ship.placed ? "which is placed" : "but it's not placed"
+      }`
+    );
+    return (
+      ship.placed &&
+      ship.partArray.find((part) => {
+        console.log(`Comparing with cell ${part.location}`);
+        return part.location[0] === x && part.location[1] === y;
+      })
+    );
+  });
+};

--- a/packages/client/lib/interfaces/types.ts
+++ b/packages/client/lib/interfaces/types.ts
@@ -6,11 +6,17 @@ export enum shipLength {
   Carrier = 5,
 }
 
+export type ShipPart = {
+  location: number[];
+  hit: boolean;
+};
+
+export type ShipInfo = {
+  shipType: string;
+  placed: boolean;
+  partArray: ShipPart[];
+};
+
 export type playerData = {
-  board: number[][];
-  shipInfo: {
-    shipType: string;
-    placed: boolean;
-    placedLocation: number[][];
-  }[];
+  shipInfo: ShipInfo[];
 };

--- a/packages/client/lib/sections/Game.tsx
+++ b/packages/client/lib/sections/Game.tsx
@@ -1,11 +1,7 @@
-import type { NextPage } from "next";
 import React, { useState, useRef, useEffect } from "react";
 import Board from "../components/Board";
-import boardWithRandomlyPlacedShips from "../functions/generateRandomPlacements";
 import { playerData } from "../interfaces/types";
 // import ServerTest from "../lib/components/ServerTest";
-import Ship from "../components/Ship";
-import { shipLengths } from "../constants";
 
 //Conditions 'Sunk' | 'Hit' | 'Miss' | 'Ship' | 'Empty'
 
@@ -25,8 +21,8 @@ const Game = (props: Props) => {
   /** update board array after checking with placed location */
   function updateHit(
     location: number[],
-    userData: playerData,
-    setData: React.Dispatch<React.SetStateAction<playerData>>
+    playerData: playerData,
+    setPlayerData: React.Dispatch<React.SetStateAction<playerData>>
   ) {
     // condition for userturn
 
@@ -36,23 +32,24 @@ const Game = (props: Props) => {
     // If location already shot, alert pick another location
 
     // const hitStatus = checkHit(location, props.playerData);
-    const { index, shipHit } = checkHit(location, userData);
+    const { index, shipHit } = checkHit(location, playerData);
     console.log("index of the placedLocation: " + index);
     console.log("shipType hit: " + shipHit);
 
     // IF MISS
+
     if (index === -1) {
       //first number as row
       console.log("miss");
 
       // Make this piece of code reusable -> updates board and placedlocation
-      setData((prev) => {
-        const updatedBoard = prev.board.map((row, i) => {
-          if (i === x) {
-            return row.map((cell, j) => (j === y ? -1 : cell));
-          }
-          return row;
-        });
+      setPlayerData((prev) => {
+        // const updatedBoard = prev.board.map((row, i) => {
+        //   if (i === x) {
+        //     return row.map((cell, j) => (j === y ? -1 : cell));
+        //   }
+        //   return row;
+        // });
         // const updatedMissedShotsArray = prev.shipInfo.map((ship, i) =>
         //   i === index
         //     ? {
@@ -63,25 +60,24 @@ const Game = (props: Props) => {
         // );
         return {
           ...prev,
-          board: updatedBoard,
           // shipInfo: updatedMissedShotsArray,
         };
       });
     } else {
       console.log(props.playerData.shipInfo[shipHit]?.shipType + "-" + index);
 
-      setData((prev) => {
-        const updatedBoard = prev.board.map((row, i) => {
-          if (i === x) {
-            return row.map((cell, j) => (j === y ? -9 : cell));
-          }
-          return row;
-        });
+      setPlayerData((prev) => {
+        // const updatedBoard = prev.board.map((row, i) => {
+        //   if (i === x) {
+        //     return row.map((cell, j) => (j === y ? -9 : cell));
+        //   }
+        //   return row;
+        // });
 
-        prev.shipInfo[shipHit].placedLocation[index] = [-x, -y];
+        // prev.shipInfo[shipHit].placedLocation[index] = [-x, -y];
 
         console.log("PLZ: " + JSON.stringify(prev.shipInfo));
-        return { ...prev, board: updatedBoard, shipInfo: prev.shipInfo };
+        return { ...prev, shipInfo: prev.shipInfo };
       });
     }
   }
@@ -92,7 +88,7 @@ const Game = (props: Props) => {
   function checkHit(location: number[], board: playerData) {
     const indexAndShipType = board.shipInfo.reduce(
       (result, info, shipType) => {
-        const index = info.placedLocation.findIndex(
+        const index = info.partArray.findIndex(
           (locations) => JSON.stringify(locations) === JSON.stringify(location)
         );
         if (index >= 0) {
@@ -131,24 +127,21 @@ const Game = (props: Props) => {
   return (
     <div className="main-container">
       <div className="game-container">
-        <div className="grid-value battleship-grid">
-          <Board
-            selectedShipIndex={selectedShipIndex}
-            setPlayerData={props.setPlayerData}
-            playerData={props.playerData}
-            setUserTurn={setUserTurn}
-            setUserFireLocation={setUserFireLocation}
-          ></Board>
-        </div>
-        <div className="grid-value battleship-grid">
-          <Board
-            selectedShipIndex={selectedShipIndex}
-            setPlayerData={props.setOpponentData}
-            playerData={props.opponentData}
-            setUserTurn={setUserTurn}
-            setUserFireLocation={setUserFireLocation}
-          ></Board>
-        </div>
+        <Board
+          selectedShipIndex={selectedShipIndex}
+          setPlayerData={props.setPlayerData}
+          playerData={props.playerData}
+          setUserTurn={setUserTurn}
+          setUserFireLocation={setUserFireLocation}
+        />
+
+        <Board
+          selectedShipIndex={selectedShipIndex}
+          setPlayerData={props.setOpponentData}
+          playerData={props.opponentData}
+          setUserTurn={setUserTurn}
+          setUserFireLocation={setUserFireLocation}
+        />
       </div>
       {/* <ServerTest /> */}
     </div>

--- a/packages/client/lib/sections/Starter.tsx
+++ b/packages/client/lib/sections/Starter.tsx
@@ -1,7 +1,6 @@
 import type { NextPage } from "next";
 import React, { useState, useRef } from "react";
 import Board from "../components/Board";
-import boardWithRandomlyPlacedShips from "../functions/generateRandomPlacements";
 import { playerData } from "../interfaces/types";
 // import ServerTest from "../lib/components/ServerTest";
 import Ship from "../components/Ship";

--- a/packages/client/lib/sections/Starter.tsx
+++ b/packages/client/lib/sections/Starter.tsx
@@ -42,18 +42,18 @@ const Starter = (props: Props) => {
   function handleReset() {
     props.setPlayerData(() => {
       let prev = { ...props.playerData };
-      prev.board = newBoard();
       prev.shipInfo.map(
-        (info) => ((info.placed = false), (info.placedLocation = []))
+        (info) => ((info.placed = false), (info.partArray = []))
       );
       console.log(prev);
       return prev;
     });
   }
+  // console.table(playerData.board);
 
   function randomPlacement() {
     handleReset();
-    generateRandomPlacements(props.playerData.board, props.setPlayerData);
+    generateRandomPlacements(props.setPlayerData, props.playerData);
   }
 
   //stored in server?
@@ -61,16 +61,14 @@ const Starter = (props: Props) => {
   return (
     <div className="main-container" ref={dragConstraintsRef}>
       <div className="game-container">
-        <div className="grid-value battleship-grid">
-          <Board
-            orientation={placementOrientation}
-            isShipSelected={isShipSelected}
-            setIsShipSelected={setIsShipSelected}
-            selectedShipIndex={selectedShipIndex}
-            setPlayerData={props.setPlayerData}
-            playerData={props.playerData}
-          ></Board>
-        </div>
+        <Board
+          orientation={placementOrientation}
+          isShipSelected={isShipSelected}
+          setIsShipSelected={setIsShipSelected}
+          selectedShipIndex={selectedShipIndex}
+          setPlayerData={props.setPlayerData}
+          playerData={props.playerData}
+        />
       </div>
 
       {/* <ServerTest /> */}

--- a/packages/client/pages/index.tsx
+++ b/packages/client/pages/index.tsx
@@ -1,13 +1,11 @@
 import type { NextPage } from "next";
-import React, { useState, useRef } from "react";
-import Board from "../lib/components/Board";
+import React, { useState } from "react";
 import generateRandomPlacements from "../lib/functions/generateRandomPlacements";
-import { shipLength } from "../lib/interfaces/types";
+import { playerData } from "../lib/interfaces/types";
 // import ServerTest from "../lib/components/ServerTest";
-import Ship from "../lib/components/Ship";
 import Starter from "../lib/sections/Starter";
 import Game from "../lib/sections/Game";
-import { initialData, shipLengths } from "../lib/constants";
+import { initialData } from "../lib/constants";
 
 //Conditions 'Sunk' | 'Hit' | 'Miss' | 'Ship' | 'Empty'
 
@@ -18,21 +16,13 @@ const Home: NextPage = () => {
   // const [playerBoard, setPlayerBoard] = useState<number[][]>(newBoard());
   // const [opponentBoard, setOpponentBoard] = useState<number[][]>(newBoard());
 
-  const [playerData, setPlayerData] = useState({
-    board: newBoard(),
+  const [playerData, setPlayerData] = useState<playerData>({
     shipInfo: initialData,
   });
 
-  const [opponentData, setOpponentData] = useState({
-    board: newBoard(),
+  const [opponentData, setOpponentData] = useState<playerData>({
     shipInfo: initialData,
   });
-
-  function newBoard() {
-    return Array(width)
-      .fill(0)
-      .map(() => Array(width).fill(0));
-  }
 
   /** Resets the board with zero populated array & places ships randomly on it */
   function handleStart() {
@@ -58,9 +48,8 @@ const Home: NextPage = () => {
     //   });
     // });
 
-    generateRandomPlacements(opponentData.board, setOpponentData);
+    generateRandomPlacements(setOpponentData, opponentData);
     setGameStart(true);
-    console.table(playerData.board);
   }
 
   return (

--- a/packages/client/pages/index.tsx
+++ b/packages/client/pages/index.tsx
@@ -5,8 +5,8 @@ import generateRandomPlacements from "../lib/functions/generateRandomPlacements"
 import { shipLength } from "../lib/interfaces/types";
 // import ServerTest from "../lib/components/ServerTest";
 import Ship from "../lib/components/Ship";
-import Starter from "../lib/sections/starter";
-import Game from "../lib/sections/game";
+import Starter from "../lib/sections/Starter";
+import Game from "../lib/sections/Game";
 import { initialData, shipLengths } from "../lib/constants";
 
 //Conditions 'Sunk' | 'Hit' | 'Miss' | 'Ship' | 'Empty'


### PR DESCRIPTION
Current data structure makes players store information of their board filled with information of ship's location, while also storing information about their ship's properties; which includes it's own location. This means that there are two sources of truth for a ship's location, requiring more work in synchronizing and manipulating the data.

This pull request sets a foundation to create only one source of truth: Players will no longer store information of their board, but only about their ship's properties and where they have shot in the past. This pull request has not set up information about where players have shot in the past. Hoping you can do that part.

The frontend of the board used to be constructed based on the board information stored in the players. Now, it is always an empty board of size 10x10, filled with cells. The cells independently check if there is any ship part located in its own location and display value accordingly.

With this change, checking if a ship has sunk only needs to check the player's ship information; if all parts of a ship has `hit: true`, then it is sunk.

The hit check function is broken and needs to be fixed - hoping you can do that as well.

It would also be nice if you can optimize the `placeShip` function - it currently checks the same tiles multiple times.